### PR TITLE
Trim all \u200b(ZERO WIDTH SPACE) from result text

### DIFF
--- a/trans.go
+++ b/trans.go
@@ -2,6 +2,7 @@ package trans
 
 import (
 	"context"
+	"strings"
 
 	"cloud.google.com/go/translate"
 	"golang.org/x/text/language"
@@ -45,5 +46,8 @@ func (c *Client) Translate(ctx context.Context, input string, s string, t string
 		return "", err
 	}
 
-	return res[0].Text, nil
+	// trim \u200b (ZERO WIDTH SPACE)
+	// http://unicode.org/cldr/utility/character.jsp?a=200B
+	// https://www.fileformat.info/info/unicode/char/200B/index.htm
+	return strings.Replace(res[0].Text, "\u200b", "", -1), nil
 }


### PR DESCRIPTION
## What 
Trim all `\u200b`(ZERO WIDTH SPACE) from result text

## Why
`result[0].Text` sometimes included '\u200b' at unnecessary position.
I don't why exist, but trimming uses `strings.Replace` workaround.

## Reproduce
This problem might be related to the terminal applications Unicode parser. If so(if you can't reproduce), sorry, ignore this pull request. I use forked `utahta/trans` in the future.

FYI, I use tmux in [github.com/kovidgoyal/kitty](https://github.com/kovidgoyal/kitty) (which GPU accelerated terminal emulator. If you interested, let's try it :D)

```diff
diff --git a/trans.go b/trans.go
index 598a2b3..d001f28 100644
--- a/trans.go
+++ b/trans.go
@@ -2,6 +2,7 @@ package trans
 
 import (
 	"context"
+	"fmt"
 
 	"cloud.google.com/go/translate"
 	"golang.org/x/text/language"
@@ -44,6 +45,7 @@ func (c *Client) Translate(ctx context.Context, input string, s string, t string
 	if err != nil {
 		return "", err
 	}
+	fmt.Printf("res[0].Text: %#v\n", res[0].Text)
 
 	return res[0].Text, nil
 }
```

```console
$ go run ./cmd/trans -t ja -c /path/to/sa.json 'This could happen if a library first identifies the channel, and a plugin using that library later overrides that info'
res[0].Text: "これは、ライブラリが最初にチャネルを識別し、そのライブラリを使用しているプラ\u200b\u200bグインが後でその情報を上書きする"
これは、ライブラリが最初にチャネルを識別し、そのライブラリを使用しているプラグインが後でその情報を上書きする
```

Also, it happened on the Neovim (included `<200b>`):

![screen shot 2018-08-05 at 15 52 56](https://user-images.githubusercontent.com/6366270/43683488-b3d54bea-98c7-11e8-9f98-c4b5e226301f.png)
